### PR TITLE
Initial Micrometer 1.13.x migration recipe

### DIFF
--- a/src/main/resources/META-INF/rewrite/micrometer-13.yml
+++ b/src/main/resources/META-INF/rewrite/micrometer-13.yml
@@ -1,0 +1,37 @@
+#
+# Copyright 2024 the original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.micrometer.UpgradeMicrometer13
+displayName: Migrate to Micrometer 1.13
+description: >
+  Migrate applications to the latest Micrometer 1.13 release. This recipe will modify an
+  application's build files, make changes to deprecated/preferred APIs, and migrate configuration settings that have
+  changes between versions as described in the [Micrometer 1.13 migration guide](https://github.com/micrometer-metrics/micrometer/wiki/1.13-Migration-Guide)
+tags:
+  - micrometer
+recipeList:
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: io.micrometer
+      artifactId: '*'
+      newVersion: 1.13.x
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: io.micrometer.prometheus
+      newPackageName: io.micrometer.prometheusmetrics
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: io.prometheus.client.CollectorRegistry
+      newFullyQualifiedTypeName: io.prometheus.metrics.model.registry.PrometheusRegistry
+

--- a/src/main/resources/META-INF/rewrite/micrometer.yml
+++ b/src/main/resources/META-INF/rewrite/micrometer.yml
@@ -19,7 +19,4 @@ name: org.openrewrite.micrometer.UpgradeMicrometer
 displayName: Upgrade Micrometer
 description: This recipe will apply changes commonly needed when migrating Micrometer.
 recipeList:
-  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
-      groupId: io.micrometer
-      artifactId: micrometer-core
-      newVersion: 1.x
+  - org.openrewrite.micrometer.UpgradeMicrometer13

--- a/src/test/java/org/openrewrite/micrometer/UpgradeMicrometer.java
+++ b/src/test/java/org/openrewrite/micrometer/UpgradeMicrometer.java
@@ -22,8 +22,7 @@ import org.openrewrite.config.Environment;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
-import java.util.regex.Pattern;
-
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.maven.Assertions.pomXml;
 
 class UpgradeMicrometer implements RewriteTest {
@@ -42,8 +41,8 @@ class UpgradeMicrometer implements RewriteTest {
         @DocumentExample
         void maven() {
             rewriteRun(
-              //language=xml
               pomXml(
+                //language=xml
                 """
                   <?xml version="1.0" encoding="UTF-8"?>
                   <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -61,23 +60,14 @@ class UpgradeMicrometer implements RewriteTest {
                     </dependencies>
                   </project>
                   """,
-                spec -> spec.after(actual -> """
-                  <?xml version="1.0" encoding="UTF-8"?>
-                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-                    <modelVersion>4.0.0</modelVersion>
-                    <groupId>com.example</groupId>
-                    <artifactId>demo</artifactId>
-                    <version>0.0.1-SNAPSHOT</version>
-                    <dependencies>
-                      <dependency>
-                        <groupId>io.micrometer</groupId>
-                        <artifactId>micrometer-core</artifactId>
-                        <version>%s</version>
-                      </dependency>
-                    </dependencies>
-                  </project>
-                  """.formatted(Pattern.compile("<version>(1\\.1[1-9]\\.\\d+)</version>").matcher(actual).results().findFirst().orElseThrow().group(1)))));
+                spec -> spec.after(actual -> {
+                    assertThat(actual)
+                      .as("Any version of Micrometer above 1.10.x")
+                      .containsPattern("<version>1\\.1[1-9]\\.\\d+</version>");
+                    return actual;
+                })
+              )
+            );
         }
     }
 }

--- a/src/test/java/org/openrewrite/micrometer/UpgradeMicrometer13Test.java
+++ b/src/test/java/org/openrewrite/micrometer/UpgradeMicrometer13Test.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.micrometer;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/openrewrite/micrometer/UpgradeMicrometer13Test.java
+++ b/src/test/java/org/openrewrite/micrometer/UpgradeMicrometer13Test.java
@@ -23,7 +23,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
-public class UpgradeMicrometer13Test implements RewriteTest {
+class UpgradeMicrometer13Test implements RewriteTest {
 
 	@Override
 	public void defaults( RecipeSpec spec ) {

--- a/src/test/java/org/openrewrite/micrometer/UpgradeMicrometer13Test.java
+++ b/src/test/java/org/openrewrite/micrometer/UpgradeMicrometer13Test.java
@@ -1,0 +1,88 @@
+package org.openrewrite.micrometer;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.config.Environment;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+public class UpgradeMicrometer13Test implements RewriteTest {
+
+	@Override
+	public void defaults( RecipeSpec spec ) {
+
+		spec.recipe( Environment.builder()
+		  .scanRuntimeClasspath( "org.openrewrite.micrometer" )
+		  .build()
+		  .activateRecipes( "org.openrewrite.micrometer.UpgradeMicrometer13" ) );
+	}
+
+	@Test
+	@DocumentExample
+	void shouldChangePackage() {
+		// language=java
+		rewriteRun(
+		  java(
+			"""
+			package example;
+
+			import io.micrometer.prometheus.PrometheusConfig;
+			import io.micrometer.prometheus.PrometheusMeterRegistry;
+
+			class MicrometerConfig {
+				PrometheusMeterRegistry prometheusMeterRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+			}
+			""",
+			"""
+			package example;
+
+			import io.micrometer.prometheusmetrics.PrometheusConfig;
+			import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
+
+			class MicrometerConfig {
+				PrometheusMeterRegistry prometheusMeterRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+			}
+			"""
+		  )
+		);
+	}
+
+	@Test
+	@DocumentExample
+	void shouldMigrateToPrometheusMeterRegistry() {
+		// language=java
+		rewriteRun(
+		  java(
+			"""
+			package example;
+
+			import io.micrometer.core.instrument.Clock;
+			import io.micrometer.prometheus.PrometheusConfig;
+			import io.micrometer.prometheus.PrometheusMeterRegistry;
+			import io.prometheus.client.CollectorRegistry;
+
+			class MicrometerConfig {
+				PrometheusMeterRegistry prometheusMeterRegistry = 
+					new PrometheusMeterRegistry(PrometheusConfig.DEFAULT, CollectorRegistry.defaultRegistry, Clock.SYSTEM);
+			}
+			""",
+			"""
+			package example;
+
+			import io.micrometer.core.instrument.Clock;
+			import io.micrometer.prometheusmetrics.PrometheusConfig;
+			import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
+			import io.prometheus.metrics.model.registry.PrometheusRegistry;
+
+			class MicrometerConfig {
+				PrometheusMeterRegistry prometheusMeterRegistry = 
+					new PrometheusMeterRegistry(PrometheusConfig.DEFAULT, PrometheusRegistry.defaultRegistry, Clock.SYSTEM);
+			}
+			"""
+		  )
+		);
+	}
+
+}

--- a/src/test/java/org/openrewrite/micrometer/UpgradeMicrometer13Test.java
+++ b/src/test/java/org/openrewrite/micrometer/UpgradeMicrometer13Test.java
@@ -17,7 +17,6 @@ package org.openrewrite.micrometer;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
-import org.openrewrite.config.Environment;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -25,79 +24,67 @@ import static org.openrewrite.java.Assertions.java;
 
 class UpgradeMicrometer13Test implements RewriteTest {
 
-	@Override
-	public void defaults( RecipeSpec spec ) {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipeFromResource(
+          "/META-INF/rewrite/micrometer-13.yml",
+          "org.openrewrite.micrometer.UpgradeMicrometer13");
+    }
 
-		spec.recipe( Environment.builder()
-		  .scanRuntimeClasspath( "org.openrewrite.micrometer" )
-		  .build()
-		  .activateRecipes( "org.openrewrite.micrometer.UpgradeMicrometer13" ) );
-	}
+    @Test
+    @DocumentExample
+    void shouldChangePackage() {
+        // language=java
+        rewriteRun(
+          java(
+            """
+              import io.micrometer.prometheus.PrometheusConfig;
+              import io.micrometer.prometheus.PrometheusMeterRegistry;
 
-	@Test
-	@DocumentExample
-	void shouldChangePackage() {
-		// language=java
-		rewriteRun(
-		  java(
-			"""
-			package example;
+              class MicrometerConfig {
+                  PrometheusMeterRegistry prometheusMeterRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+              }
+              """,
+            """
+              import io.micrometer.prometheusmetrics.PrometheusConfig;
+              import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 
-			import io.micrometer.prometheus.PrometheusConfig;
-			import io.micrometer.prometheus.PrometheusMeterRegistry;
+              class MicrometerConfig {
+                  PrometheusMeterRegistry prometheusMeterRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+              }
+              """
+          )
+        );
+    }
 
-			class MicrometerConfig {
-				PrometheusMeterRegistry prometheusMeterRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
-			}
-			""",
-			"""
-			package example;
+    @Test
+    void shouldMigrateToPrometheusMeterRegistry() {
+        // language=java
+        rewriteRun(
+          java(
+            """
+              import io.micrometer.core.instrument.Clock;
+              import io.micrometer.prometheus.PrometheusConfig;
+              import io.micrometer.prometheus.PrometheusMeterRegistry;
+              import io.prometheus.client.CollectorRegistry;
 
-			import io.micrometer.prometheusmetrics.PrometheusConfig;
-			import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
+              class MicrometerConfig {
+                  PrometheusMeterRegistry prometheusMeterRegistry =
+                      new PrometheusMeterRegistry(PrometheusConfig.DEFAULT, CollectorRegistry.defaultRegistry, Clock.SYSTEM);
+              }
+              """,
+            """
+              import io.micrometer.core.instrument.Clock;
+              import io.micrometer.prometheusmetrics.PrometheusConfig;
+              import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
+              import io.prometheus.metrics.model.registry.PrometheusRegistry;
 
-			class MicrometerConfig {
-				PrometheusMeterRegistry prometheusMeterRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
-			}
-			"""
-		  )
-		);
-	}
-
-	@Test
-	@DocumentExample
-	void shouldMigrateToPrometheusMeterRegistry() {
-		// language=java
-		rewriteRun(
-		  java(
-			"""
-			package example;
-
-			import io.micrometer.core.instrument.Clock;
-			import io.micrometer.prometheus.PrometheusConfig;
-			import io.micrometer.prometheus.PrometheusMeterRegistry;
-			import io.prometheus.client.CollectorRegistry;
-
-			class MicrometerConfig {
-				PrometheusMeterRegistry prometheusMeterRegistry = 
-					new PrometheusMeterRegistry(PrometheusConfig.DEFAULT, CollectorRegistry.defaultRegistry, Clock.SYSTEM);
-			}
-			""",
-			"""
-			package example;
-
-			import io.micrometer.core.instrument.Clock;
-			import io.micrometer.prometheusmetrics.PrometheusConfig;
-			import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
-			import io.prometheus.metrics.model.registry.PrometheusRegistry;
-
-			class MicrometerConfig {
-				PrometheusMeterRegistry prometheusMeterRegistry = 
-					new PrometheusMeterRegistry(PrometheusConfig.DEFAULT, PrometheusRegistry.defaultRegistry, Clock.SYSTEM);
-			}
-			"""
-		  )
-		);
-	}
-
+              class MicrometerConfig {
+                  PrometheusMeterRegistry prometheusMeterRegistry =
+                      new PrometheusMeterRegistry(PrometheusConfig.DEFAULT, PrometheusRegistry.defaultRegistry, Clock.SYSTEM);
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?
Initial work on [Migrate to micrometer v1.13.+](https://github.com/openrewrite/rewrite-micrometer/issues/8)

## What's your motivation?
* https://github.com/openrewrite/rewrite-micrometer/issues/8

## Anything in particular you'd like reviewers to focus on?
* How should this be incorporated into the "main" upgrade recipe?
* Does the build need changes (with regards to pinnig)
* Are the tests good enough?

## Anyone you would like to review specifically?
@timtebeek 

## Any additional context
The migration from `io.prometheus.client.CollectorRegistry` to `io.prometheus.metrics.model.registry.PrometheusRegistry` is probably not covering _all_ cases.
But for many code bases simply changing the type might be sufficient because `CollectorRegistry` and `PrometheusRegistry` have a very similar (and small) public api that essentially only offers a singleton - exposed as constant with equal names - and a constructor

### Checklist
- [] I've added unit tests to cover both positive and negative cases (sort of - no negative cases 😢 )
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
