### PR TITLE
Drop Java 11 requirement brought in by misk

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,11 +5,6 @@ plugins {
 group = "org.openrewrite.recipe"
 description = "Micrometer Migration"
 
-tasks.getByName<JavaCompile>("compileJava") {
-    // minimum required for misk use in refaster-style templates
-    options.release.set(11)
-}
-
 val rewriteVersion = rewriteRecipe.rewriteVersion.get()
 val micrometerVersion = "1.12.+"
 dependencies {
@@ -27,7 +22,6 @@ dependencies {
 
     compileOnly("org.jetbrains.kotlin:kotlin-stdlib-common:1.9.0")
     compileOnly("org.jetbrains.kotlin:kotlin-reflect:1.9.0")
-    compileOnly("com.squareup.misk:misk-metrics:2023.09.27.194750-c3aa143")
     compileOnly("io.micrometer:micrometer-core:${micrometerVersion}")
     compileOnly("io.prometheus:simpleclient:latest.release")
 

--- a/src/main/java/org/openrewrite/micrometer/dropwizard/FindDropwizardMetrics.java
+++ b/src/main/java/org/openrewrite/micrometer/dropwizard/FindDropwizardMetrics.java
@@ -42,7 +42,7 @@ public class FindDropwizardMetrics extends Recipe {
         MethodMatcher counter = new MethodMatcher("com.codahale.metrics.MetricRegistry counter(..)");
         MethodMatcher gauge = new MethodMatcher("com.codahale.metrics.MetricRegistry gauge(..)");
 
-        return new JavaIsoVisitor<>() {
+        return new JavaIsoVisitor<ExecutionContext>() {
             @Override
             public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                 if (counter.matches(method) || gauge.matches(method)) {

--- a/src/main/java/org/openrewrite/micrometer/misk/MigrateEmptyLabelMiskCounter.java
+++ b/src/main/java/org/openrewrite/micrometer/misk/MigrateEmptyLabelMiskCounter.java
@@ -51,9 +51,8 @@ public class MigrateEmptyLabelMiskCounter extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return Preconditions.check(new UsesType<>("misk.metrics.v2.Metrics", true), new JavaIsoVisitor<>() {
+        return Preconditions.check(new UsesType<>("misk.metrics.v2.Metrics", true), new JavaIsoVisitor<ExecutionContext>() {
             final MethodMatcher miskCounter = new MethodMatcher("misk.metrics.v2.Metrics counter(..)");
-            final MethodMatcher listOf = new MethodMatcher("kotlin.collections.CollectionsKt listOf()", true);
 
             @Override
             public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {

--- a/src/main/java/org/openrewrite/micrometer/misk/NoExplicitEmptyLabelList.java
+++ b/src/main/java/org/openrewrite/micrometer/misk/NoExplicitEmptyLabelList.java
@@ -15,21 +15,18 @@
  */
 package org.openrewrite.micrometer.misk;
 
-import misk.metrics.v2.Metrics;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaParser;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.TypeUtils;
 
 import java.util.Arrays;
 import java.util.List;
-
-import static kotlin.collections.CollectionsKt.listOf;
-import static org.openrewrite.java.template.Semantics.expression;
 
 public class NoExplicitEmptyLabelList extends Recipe {
 
@@ -46,15 +43,20 @@ public class NoExplicitEmptyLabelList extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
 
-        return new JavaIsoVisitor<>() {
+        return new JavaIsoVisitor<ExecutionContext>() {
             final List<JavaTemplate> hasEmptyLabel = Arrays.asList(
-                    expression(this, "emptyLabelCounter",
-                            (Metrics m, String s, String s1) -> m.counter(s, s1, listOf())).build(),
-                    expression(this, "emptyLabelGauge",
-                            (Metrics m, String s, String s1) -> m.gauge(s, s1, listOf())).build(),
-                    expression(this, "emptyLabelPeakGauge",
-                            (Metrics m, String s, String s1) -> m.peakGauge(s, s1, listOf())).build()
-            );
+                    JavaTemplate.builder("#{m:any(misk.metrics.v2.Metrics)}.counter(#{s:any(java.lang.String)}, #{s1:any(java.lang.String)}, listOf())")
+                            .staticImports("kotlin.collections.CollectionsKt.listOf")
+                            .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))
+                            .build(),
+                    JavaTemplate.builder("#{m:any(misk.metrics.v2.Metrics)}.gauge(#{s:any(java.lang.String)}, #{s1:any(java.lang.String)}, listOf())")
+                            .staticImports("kotlin.collections.CollectionsKt.listOf")
+                            .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))
+                            .build(),
+                    JavaTemplate.builder("#{m:any(misk.metrics.v2.Metrics)}.peakGauge(#{s:any(java.lang.String)}, #{s1:any(java.lang.String)}, listOf())")
+                            .staticImports("kotlin.collections.CollectionsKt.listOf")
+                            .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))
+                            .build());
 
             @Override
             public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {

--- a/src/test/java/org/openrewrite/micrometer/misk/NoExplicitEmptyLabelListTest.java
+++ b/src/test/java/org/openrewrite/micrometer/misk/NoExplicitEmptyLabelListTest.java
@@ -43,7 +43,7 @@ class NoExplicitEmptyLabelListTest implements RewriteTest {
             """
               import misk.metrics.v2.Metrics;
               import static kotlin.collections.CollectionsKt.listOf;
-                            
+
               class Test {
                 void test(Metrics metrics) {
                     metrics.counter("counter", "description", listOf());
@@ -55,7 +55,7 @@ class NoExplicitEmptyLabelListTest implements RewriteTest {
             """
               import misk.metrics.v2.Metrics;
               import static kotlin.collections.CollectionsKt.listOf;
-                            
+
               class Test {
                 void test(Metrics metrics) {
                     metrics.counter("counter", "description");


### PR DESCRIPTION
Copied over the generated templates and removed the misk dependency to remove the runtime requirement on Java 11+.

- Fixes https://github.com/openrewrite/rewrite-micrometer/issues/12

This then allows the Micrometer recipes to be included with our Spring Boot migrations again, as seen on
- https://github.com/openrewrite/rewrite-spring/pull/551